### PR TITLE
Separate out the "history" of SSH from the intro to the scp command

### DIFF
--- a/02-ssh.html
+++ b/02-ssh.html
@@ -34,11 +34,12 @@
 </div>
 <div class="panel-body">
 <ul>
-<li>Learn SSH and SCP to work remotely</li>
+<li>Learn what SSH is</li>
 <li>Learn what an SSH key is</li>
 <li>Generate your own SSH key pair</li>
-<li>Add your SSH key to an remote server</li>
 <li>Learn how to use your SSH key</li>
+<li>Learn how to work remotely using ‘ssh’ and ‘scp’</li>
+<li>Add your SSH key to an remote server</li>
 </ul>
 </div>
 </div>

--- a/02-ssh.html
+++ b/02-ssh.html
@@ -177,6 +177,7 @@ Password: ********</code></pre>
 <ul>
 <li>SSH is a secure alternative to username/password authorization</li>
 <li>SSH keys are generated in public/private pairs. Your public key can be shared with others. The private keys stays on your machine only.</li>
+<li>The ‘ssh’ and ‘scp’ utilities are secure alternatives to logging into, and copying files to/from remote machine</li>
 </ul>
 </div>
 </div>

--- a/02-ssh.html
+++ b/02-ssh.html
@@ -30,7 +30,7 @@
           
 <div id="learning-objectives" class="objectives panel panel-warning">
 <div class="panel-heading">
-<h2><span class="glyphicon glyphicon-certificate"></span>Learning Objectives</h2>
+<h2 id="learning-objectives" class="objectives panel panel-warning"><span class="glyphicon glyphicon-certificate"></span>Learning Objectives</h2>
 </div>
 <div class="panel-body">
 <ul>
@@ -60,12 +60,24 @@ Password: ********</code></pre>
 <pre class="input"><code>    moon&gt; exit</code></pre>
 <pre class="input"><code>$ pwd</code></pre>
 <pre class="output"><code>/users/vlad</code></pre>
-<p>The secure shell is called “secure” to contrast it with an older program called <code>rsh</code>, which stood for “remote shell”. Back in the day, when everyone trusted each other and knew every chip in their computer by its first name, people didn’t encrypt anything except the most sensitive information when sending it over a network. However, that meant that villains could watch network traffic, steal usernames and passwords, and use them for all manner of nefarious purposes. SSH was invented to prevent this (or at least slow it down). It uses several sophisticated, and heavily tested, encryption protocols to ensure that outsiders can’t see what’s in the messages going back and forth between different computers.</p>
-<p><code>ssh</code> has a companion program called <code>scp</code>, which stands for “secure copy”. It allows us to copy files to or from a remote computer using the same kind of connection as SSH. The command’s name combines <code>cp</code>’s and <code>ssh</code>’s, and so does its operation. To copy a file, we specify the source and destination paths, either of which may include computer names. If we leave out a computer name, <code>scp</code> assumes we mean the machine we’re running on. For example, this command copies our latest results to the backup server in the basement, printing out its progress as it does so:</p>
+<h3 id="ssh-history">SSH History</h3>
+<p>Back in the day, when everyone trusted each other and knew every chip in their computer by its first name, people didn’t encrypt anything except the most sensitive information when sending it over a network and the two programs used for running a shell (usually back then, the Bourne Shell, <code>sh</code>) on, or copying files to, a remote machine were named <code>rsh</code> and <code>rcp</code>, respectively. Think (<code>r</code>)emote <code>sh</code> and <code>cp</code></p>
+<p>However, anyone could watch the unencrypted network traffic, which meant that villains could steal usernames and passwords, and use them for all manner of nefarious purposes.</p>
+<p>SSH was invented to prevent this (or at least slow it down). It uses several sophisticated, and heavily tested, encryption protocols to ensure that outsiders can’t see what’s in the messages going back and forth between different computers.</p>
+<p>The “secure” version of <code>rsh</code>, called <code>ssh</code>, think (<code>s</code>)ecure <code>sh</code>, has a companion program, (<code>s</code>)ecure <code>cp</code>, called <code>scp</code>, which allows us to copy files to or from a remote computer using the same kind of encrypted connection as SSH.</p>
+<p>To copy a file, we specify the source and destination paths, either of which may include computer names. If we leave out a computer name, <code>scp</code> assumes we mean the machine we’re running on. For example, this command copies our latest results to the backup server in the basement, printing out its progress as it does so:</p>
 <pre class="input"><code>$ scp results.dat vlad@backupserver:backups/results-2011-11-11.dat
 Password: ********</code></pre>
 <pre class="output"><code>results.dat              100%  9  1.0 MB/s 00:00</code></pre>
-<p>Copying a whole directory is similar: we just use the <code>-r</code> option to signal that we want copying to be recursive. For example, this command copies all of our results from the backup server to our laptop:</p>
+<p>Note the colon <code>:</code>, seperating the hostname of the server and the pathname of the file we are copying to. It is this character that informs <code>scp</code> that the source or target of the copy is on the remote machine and the reason it is needed can be explained as follows:</p>
+<p>In the same way that the default directory into which we are placed when running a shell on a remote machine is our home directory on that machine, the default target, for a remote copy, is also the home directory.</p>
+<p>This means that</p>
+<pre class="input"><code>$ scp results.dat vlad@backupserver:</code></pre>
+<p>would copy <code>results.dat</code> into our home directory on <code>backupserver</code>, however, if we did not have the colon to inform <code>scp</code> of the remote machine, we would still have a valid commmad</p>
+<pre class="input"><code>$ scp results.dat vlad@backupserver</code></pre>
+<p>but now we have merely created a file called <code>vlad@backupserver</code> on our local machine, as we would have done with <code>cp</code>.</p>
+<pre class="input"><code>$ cp results.dat vlad@backupserver</code></pre>
+<p>Copying a whole directory betwen remote machines uses the same syntax as the <code>cp</code> command: we just use the <code>-r</code> option to signal that we want copying to be recursively. For example, this command copies all of our results from the backup server to our laptop:</p>
 <pre class="input"><code>$ scp -r vlad@backupserver:backups ./backups
 Password: ********</code></pre>
 <pre class="output"><code>results-2011-09-18.dat              100%  7  1.0 MB/s 00:00
@@ -158,7 +170,7 @@ Password: ********</code></pre>
 <pre class="output"><code>    -rw------- 2 vlad vlad 512 Jan 01 09:11 /home/vlad/.ssh/authorized_keys</code></pre>
 <div id="key-points" class="callout panel panel-info">
 <div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pushpin"></span>Key Points</h2>
+<h2 id="key-points" class="callout panel panel-info"><span class="glyphicon glyphicon-pushpin"></span>Key Points</h2>
 </div>
 <div class="panel-body">
 <ul>

--- a/02-ssh.html
+++ b/02-ssh.html
@@ -143,7 +143,7 @@ Password: ********</code></pre>
 <p>The example of copying our public key to a remote machine, so that it can then be used when we next SSH into that remote machine, assumed that we already had a directory <code>~/.ssh/</code>.</p>
 <p>Whilst a remote server may support the use of SSH to login, your home directory there may not contain a <code>.ssh</code> directory by default.</p>
 <p>We have already seen that we can use SSH to run commands on remote machines, so we can ensure that everything is set up as required before we place the copy of our public key on a remote machine.</p>
-<p>Walk through this process allows to highlight some of the typical requirements of the SSH protocol itself, as documented in the man-page for the <code>ssh</code> command.</p>
+<p>Walking through this process allows us to highlight some of the typical requirements of the SSH protocol itself, as documented in the man-page for the <code>ssh</code> command.</p>
 <p>Firstly, we check that we have a <code>.ssh/</code> directory on another remote machine, <code>comet</code></p>
 <pre class="input"><code>$ ssh vlad@comet &quot;ls -ld ~/.ssh&quot;
 Password: ********</code></pre>

--- a/02-ssh.html
+++ b/02-ssh.html
@@ -38,15 +38,27 @@
 <li>Learn what an SSH key is</li>
 <li>Generate your own SSH key pair</li>
 <li>Learn how to use your SSH key</li>
-<li>Learn how to work remotely using ‘ssh’ and ‘scp’</li>
+<li>Learn how to work remotely using <code>ssh</code> and <code>scp</code></li>
 <li>Add your SSH key to an remote server</li>
 </ul>
 </div>
 </div>
 <p>Let’s take a closer look at what happens when we use the shell on a desktop or laptop computer. The first step is to log in so that the operating system knows who we are and what we’re allowed to do. We do this by typing our username and password; the operating system checks those values against its records, and if they match, runs a shell for us.</p>
 <p>As we type commands, the 1’s and 0’s that represent the characters we’re typing are sent from the keyboard to the shell. The shell displays those characters on the screen to represent what we type, and then, if what we typed was a command, the shell executes it and displays its output (if any).</p>
-<p>What if we want to run some commands on another machine, such as the server in the basement that manages our database of experimental results? To do this, we have to first log in to that machine. We call this a <a href="./reference.html#remote-login">remote login</a>, and the other computer a remote computer. Once we do this, everything we type is passed to a shell running on the remote computer. That shell runs those commands on our behalf, just as a local shell would, then sends back output for our computer to display.</p>
-<p>The tool we use to log in remotely is the <a href="./reference.html#secure-shell">secure shell</a>, or SSH. In particular, the command <code>ssh username@computer</code> runs SSH and connects to the remote computer we have specified. After we log in, we can use the remote shell to use the remote computer’s files and directories. Typing <code>exit</code> or Control-D terminates the remote shell and returns us to our previous shell.</p>
+<p>What if we want to run some commands on another machine, such as the server in the basement that manages our database of experimental results? To do this, we have to first log in to that machine. We call this a <a href="./reference.html#remote-login">remote login</a>.</p>
+<p>In order for us to be able to login, the remote computer must be runing a <a href="./reference.html#remote-login-server">remote login server</a> and we will run a client program that can talk to that server. The client program passes our login credentials to the remote login server and, if we are allowed to login, that server then runs a shell for us on the remote computer.</p>
+<p>Once our local client is connected to the remote server, everything we type into the client is passed on, by the server, to the shell running on the remote computer. That remote shell runs those commands on our behalf, just as a local shell would, then sends back output, via the server, to our client, for our computer to display.</p>
+<h3 id="ssh-history">SSH History</h3>
+<p>Back in the day, when everyone trusted each other and knew every chip in their computer by its first name, people didn’t encrypt anything except the most sensitive information when sending it over a network and the two programs used for running a shell (usually back then, the Bourne Shell, <code>sh</code>) on, or copying files to, a remote machine were named <code>rsh</code> and <code>rcp</code>, respectively. Think (<code>r</code>)emote <code>sh</code> and <code>cp</code></p>
+<p>However, anyone could watch the unencrypted network traffic, which meant that villains could steal usernames and passwords, and use them for all manner of nefarious purposes.</p>
+<p>The <a href="./reference.html#ssh-protocol">SSH protocol</a> was invented to prevent this (or at least slow it down). It uses several sophisticated, and heavily tested, encryption protocols to ensure that outsiders can’t see what’s in the messages going back and forth between different computers.</p>
+<p>The remote login server which accepts connections from client programs is known as the <a href="./reference.html#ssh-daemon">SSH daemon</a>, or <code>sshd</code>.</p>
+<p>The client program we use to login remotely is the <a href="./reference.html#secure-shell">secure shell</a>, or <code>ssh</code>, think (<code>s</code>)ecure <code>sh</code>.</p>
+<p>The <code>ssh</code> login client has a companion program called <code>scp</code>, think (<code>s</code>)ecure <code>cp</code>, which allows us to copy files to or from a remote computer using the same kind of encrypted connection.</p>
+<h3 id="a-remote-login-using-ssh">A remote login using <code>ssh</code></h3>
+<p>To make a remote login, we issue the command <code>ssh username@computer</code> which tries to make a connection to the SSH daemon running on the remote computer we have specified.</p>
+<p>After we log in, we can use the remote shell to use the remote computer’s files and directories.</p>
+<p>Typing <code>exit</code> or Control-D terminates the remote shell, and the local client program, and returns us to our previous shell.</p>
 <p>In the example below, the remote machine’s command prompt is <code>moon&gt;</code> instead of just <code>$</code>. To make it clearer which machine is doing what, we’ll indent the commands sent to the remote machine and their output.</p>
 <pre class="input"><code>$ pwd</code></pre>
 <pre class="output"><code>/users/vlad</code></pre>
@@ -61,11 +73,7 @@ Password: ********</code></pre>
 <pre class="input"><code>    moon&gt; exit</code></pre>
 <pre class="input"><code>$ pwd</code></pre>
 <pre class="output"><code>/users/vlad</code></pre>
-<h3 id="ssh-history">SSH History</h3>
-<p>Back in the day, when everyone trusted each other and knew every chip in their computer by its first name, people didn’t encrypt anything except the most sensitive information when sending it over a network and the two programs used for running a shell (usually back then, the Bourne Shell, <code>sh</code>) on, or copying files to, a remote machine were named <code>rsh</code> and <code>rcp</code>, respectively. Think (<code>r</code>)emote <code>sh</code> and <code>cp</code></p>
-<p>However, anyone could watch the unencrypted network traffic, which meant that villains could steal usernames and passwords, and use them for all manner of nefarious purposes.</p>
-<p>SSH was invented to prevent this (or at least slow it down). It uses several sophisticated, and heavily tested, encryption protocols to ensure that outsiders can’t see what’s in the messages going back and forth between different computers.</p>
-<p>The “secure” version of <code>rsh</code>, called <code>ssh</code>, think (<code>s</code>)ecure <code>sh</code>, has a companion program, (<code>s</code>)ecure <code>cp</code>, called <code>scp</code>, which allows us to copy files to or from a remote computer using the same kind of encrypted connection as SSH.</p>
+<h3 id="copying-files-to-and-from-a-remote-machine-using-scp">Copying files to, and from a remote machine using <code>scp</code></h3>
 <p>To copy a file, we specify the source and destination paths, either of which may include computer names. If we leave out a computer name, <code>scp</code> assumes we mean the machine we’re running on. For example, this command copies our latest results to the backup server in the basement, printing out its progress as it does so:</p>
 <pre class="input"><code>$ scp results.dat vlad@backupserver:backups/results-2011-11-11.dat
 Password: ********</code></pre>
@@ -85,12 +93,13 @@ Password: ********</code></pre>
 results-2011-10-04.dat              100%  9  1.0 MB/s 00:00
 results-2011-10-28.dat              100%  8  1.0 MB/s 00:00
 results-2011-11-11.dat              100%  9  1.0 MB/s 00:00</code></pre>
-<p>Here’s one more thing SSH can do for us. Suppose we want to check whether we have already created the file <code>backups/results-2011-11-12.dat</code> on the backup server. Instead of logging in and then typing <code>ls</code>, we could do this:</p>
+<h3 id="running-commands-on-a-remote-machine-using-ssh">Running commands on a remote machine using <code>ssh</code></h3>
+<p>Here’s one more thing the <code>ssh</code> client program can do for us. Suppose we want to check whether we have already created the file <code>backups/results-2011-11-12.dat</code> on the backup server. Instead of logging in and then typing <code>ls</code>, we could do this:</p>
 <pre class="input"><code>$ ssh vlad@backupserver &quot;ls results*&quot;
 Password: ********</code></pre>
 <pre class="output"><code>results-2011-09-18.dat  results-2011-10-28.dat
 results-2011-10-04.dat  results-2011-11-11.dat</code></pre>
-<p>SSH takes the argument after our remote username and passes them to the shell on the remote computer. (We have to put quotes around it to make it look like a single argument.) Since those arguments are a legal command, the remote shell runs <code>ls results</code> for us and sends the output back to our local shell for display.</p>
+<p>Here, <code>ssh</code> takes the argument after our remote username and passes them to the shell on the remote computer. (We have to put quotes around it to make it look like a single argument.) Since those arguments are a legal command, the remote shell runs <code>ls results</code> for us and sends the output back to our local shell for display.</p>
 <h3 id="ssh-keys">SSH Keys</h3>
 <p>Typing our password over and over again is annoying, especially if the commands we want to run remotely are in a loop. To remove the need to do this, we can create an <a href="./reference.html#ssh-key">SSH key</a> to tell the remote machine that it should always trust us.</p>
 <p>SSH keys come in pairs, a public key that gets shared with services like GitHub, and a private key that is stored only on your computer. If the keys match, you’re granted access.</p>

--- a/02-ssh.md
+++ b/02-ssh.md
@@ -414,3 +414,4 @@ $ ssh vlad@comet "chmod go-r ~/.ssh/authorized_keys ; ls -l ~/.ssh"
 > ## Key Points  {.callout}
 > *  SSH is a secure alternative to username/password authorization
 > *  SSH keys are generated in public/private pairs. Your public key can be shared with others. The private keys stays on your machine only.
+> *  The 'ssh' and 'scp' utilities are secure alternatives to logging into, and copying files to/from remote machine

--- a/02-ssh.md
+++ b/02-ssh.md
@@ -4,11 +4,12 @@ title: Working Remotely
 ---
 > ## Learning Objectives  {.objectives}
 >
-> *   Learn SSH and SCP to work remotely
+> *   Learn what SSH is
 > *   Learn what an SSH key is
 > *   Generate your own SSH key pair
-> *   Add your SSH key to an remote server
 > *   Learn how to use your SSH key
+> *   Learn how to work remotely using 'ssh' and 'scp'
+> *   Add your SSH key to an remote server
 
 Let's take a closer look at what happens when we use the shell
 on a desktop or laptop computer.

--- a/02-ssh.md
+++ b/02-ssh.md
@@ -324,7 +324,7 @@ We have already seen that we can use SSH to run commands on remote
 machines, so we can ensure that everything is set up as required before
 we place the copy of our public key on a remote machine.
 
-Walk through this process allows to highlight some of the typical
+Walking through this process allows us to highlight some of the typical
 requirements of the SSH protocol itself, as documented in the man-page
 for the `ssh` command.
 

--- a/02-ssh.md
+++ b/02-ssh.md
@@ -93,25 +93,26 @@ $ pwd
 /users/vlad
 ~~~
 
-The secure shell is called "secure" to contrast it with an older program called `rsh`,
-which stood for "remote shell".
+### SSH History
+
 Back in the day,
 when everyone trusted each other and knew every chip in their computer by its first name,
-people didn't encrypt anything except the most sensitive information when sending it over a network.
-However,
-that meant that villains could watch network traffic,
+people didn't encrypt anything except the most sensitive information when sending it over a network
+and the two programs used for running a shell (usually back then, the Bourne Shell, `sh`) on, or copying
+files to, a remote machine were named `rsh` and `rcp`, respectively. Think (`r`)emote `sh` and `cp`
+
+However, anyone could watch the unencrypted network traffic, which meant that villains could
 steal usernames and passwords,
 and use them for all manner of nefarious purposes.
+
 SSH was invented to prevent this (or at least slow it down).
 It uses several sophisticated, and heavily tested, encryption protocols
 to ensure that outsiders can't see what's in the messages
 going back and forth between different computers.
 
-`ssh` has a companion program called `scp`,
-which stands for "secure copy".
-It allows us to copy files to or from a remote computer using the same kind of connection as SSH.
-The command's name combines `cp`'s and `ssh`'s,
-and so does its operation.
+The "secure" version of `rsh`, called `ssh`, think (`s`)ecure `sh`, has a companion program, (`s`)ecure `cp`, called `scp`,
+which allows us to copy files to or from a remote computer using the same kind of encrypted connection as SSH.
+
 To copy a file,
 we specify the source and destination paths,
 either of which may include computer names.
@@ -129,8 +130,37 @@ Password: ********
 results.dat              100%  9  1.0 MB/s 00:00
 ~~~
 
-Copying a whole directory is similar:
-we just use the `-r` option to signal that we want copying to be recursive.
+Note the colon `:`, seperating the hostname of the server and the pathname of 
+the file we are copying to.
+It is this character that informs `scp` that the source or target of the copy is
+on the remote machine and the reason it is needed can be explained as follows:
+
+In the same way that the default directory into which we are placed when running
+a shell on a remote machine is our home directory on that machine, the default
+target, for a remote copy, is also the  home directory.
+
+This means that 
+
+~~~ {.input}
+$ scp results.dat vlad@backupserver:
+~~~
+
+would copy `results.dat` into our home directory on `backupserver`, however, if we did not
+have the colon to inform `scp` of the remote machine, we would still have a valid commmad
+
+~~~ {.input}
+$ scp results.dat vlad@backupserver
+~~~
+
+but now we have merely created a file called `vlad@backupserver` on our local machine,
+as we would have done with `cp`.
+
+~~~ {.input}
+$ cp results.dat vlad@backupserver
+~~~
+
+Copying a whole directory betwen remote machines uses the same syntax as the `cp` command:
+we just use the `-r` option to signal that we want copying to be recursively.
 For example,
 this command copies all of our results from the backup server to our laptop:
 

--- a/02-ssh.md
+++ b/02-ssh.md
@@ -8,7 +8,7 @@ title: Working Remotely
 > *   Learn what an SSH key is
 > *   Generate your own SSH key pair
 > *   Learn how to use your SSH key
-> *   Learn how to work remotely using 'ssh' and 'scp'
+> *   Learn how to work remotely using `ssh` and `scp`
 > *   Add your SSH key to an remote server
 
 Let's take a closer look at what happens when we use the shell
@@ -31,22 +31,58 @@ What if we want to run some commands on another machine,
 such as the server in the basement that manages our database of experimental results?
 To do this,
 we have to first log in to that machine.
-We call this a [remote login](./reference.html#remote-login),
-and the other computer a remote computer.
-Once we do this,
-everything we type is passed to a shell running on the remote computer.
-That shell runs those commands on our behalf,
-just as a local shell would,
-then sends back output for our computer to display.
+We call this a [remote login](./reference.html#remote-login).
 
-The tool we use to log in remotely is the [secure shell](./reference.html#secure-shell),
-or SSH.
-In particular, the command `ssh username@computer`
-runs SSH and connects to the remote computer we have specified.
+In order for us to be able to login, the remote computer must be runing 
+a [remote login server](./reference.html#remote-login-server) and we will
+run a client program that can talk to that server.
+The client program passes our login credentials to the remote login server
+and, if we are allowed to login, that server then runs a shell for us on the 
+remote computer.
+
+Once our local client is connected to the remote server,
+everything we type into the client is passed on, by the server, to the shell 
+running on the remote computer.
+That remote shell runs those commands on our behalf,
+just as a local shell would,
+then sends back output, via the server, to our client, for our computer to display.
+
+### SSH History
+
+Back in the day,
+when everyone trusted each other and knew every chip in their computer by its first name,
+people didn't encrypt anything except the most sensitive information when sending it over a network
+and the two programs used for running a shell (usually back then, the Bourne Shell, `sh`) on, or copying
+files to, a remote machine were named `rsh` and `rcp`, respectively. Think (`r`)emote `sh` and `cp`
+
+However, anyone could watch the unencrypted network traffic, which meant that villains could
+steal usernames and passwords,
+and use them for all manner of nefarious purposes.
+
+The [SSH protocol](./reference.html#ssh-protocol) was invented to prevent this (or at least slow it down).
+It uses several sophisticated, and heavily tested, encryption protocols
+to ensure that outsiders can't see what's in the messages
+going back and forth between different computers.
+
+The remote login server which accepts connections from client programs is known as the [SSH daemon](./reference.html#ssh-daemon), or `sshd`.
+
+The client program we use to login remotely is the [secure shell](./reference.html#secure-shell),
+or `ssh`, think (`s`)ecure `sh`. 
+
+The `ssh` login client has a companion program called `scp`, think  (`s`)ecure `cp`, 
+which allows us to copy files to or from a remote computer using the same kind of encrypted connection.
+
+
+### A remote login using `ssh`
+
+To make a remote login, we issue the command `ssh username@computer` 
+which tries to make a connection to the SSH daemon running on the remote computer we have specified.
+
 After we log in,
 we can use the remote shell to use the remote computer's files and directories.
+
 Typing `exit` or Control-D
-terminates the remote shell and returns us to our previous shell.
+terminates the remote shell, and the local client program, and returns us to our previous shell.
 
 In the example below,
 the remote machine's command prompt is `moon>`
@@ -94,25 +130,8 @@ $ pwd
 /users/vlad
 ~~~
 
-### SSH History
 
-Back in the day,
-when everyone trusted each other and knew every chip in their computer by its first name,
-people didn't encrypt anything except the most sensitive information when sending it over a network
-and the two programs used for running a shell (usually back then, the Bourne Shell, `sh`) on, or copying
-files to, a remote machine were named `rsh` and `rcp`, respectively. Think (`r`)emote `sh` and `cp`
-
-However, anyone could watch the unencrypted network traffic, which meant that villains could
-steal usernames and passwords,
-and use them for all manner of nefarious purposes.
-
-SSH was invented to prevent this (or at least slow it down).
-It uses several sophisticated, and heavily tested, encryption protocols
-to ensure that outsiders can't see what's in the messages
-going back and forth between different computers.
-
-The "secure" version of `rsh`, called `ssh`, think (`s`)ecure `sh`, has a companion program, (`s`)ecure `cp`, called `scp`,
-which allows us to copy files to or from a remote computer using the same kind of encrypted connection as SSH.
+### Copying files to, and from a remote machine using `scp`
 
 To copy a file,
 we specify the source and destination paths,
@@ -176,7 +195,9 @@ results-2011-10-28.dat              100%  8  1.0 MB/s 00:00
 results-2011-11-11.dat              100%  9  1.0 MB/s 00:00
 ~~~
 
-Here's one more thing SSH can do for us.
+### Running commands on a remote machine using `ssh`
+
+Here's one more thing the `ssh` client program can do for us.
 Suppose we want to check whether we have already created the file
 `backups/results-2011-11-12.dat` on the backup server.
 Instead of logging in and then typing `ls`,
@@ -191,7 +212,7 @@ results-2011-09-18.dat  results-2011-10-28.dat
 results-2011-10-04.dat  results-2011-11-11.dat
 ~~~
 
-SSH takes the argument after our remote username
+Here, `ssh` takes the argument after our remote username
 and passes them to the shell on the remote computer.
 (We have to put quotes around it to make it look like a single argument.)
 Since those arguments are a legal command,


### PR DESCRIPTION
  This probably necessitates some further refactoring of the lesson
  content but should serve to chunk things up a little more
