### PR TITLE
unset site.index for gh-pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ title: "Extra Unix Shell Material"
 contact: "mailto:lessons@software-carpentry.org"
 
 # Default web-server Index page (can be blank)
-index: "index.html"
+index:
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).


### PR DESCRIPTION
ea141f122d954e5797c9022fcf5ccf169d95642f added a site.index variable to enable local browsing of a repo after the site has been built using Jekyll by using local `file:///`links, without the need to start a local webserver with `make serve`.  This feature should probably be a PR against swcarpentry/styles.

Regardless, unsetting site.index will allow the gh-pages site to generate the correct URLs (http://swcarpentry.github.io/shell-extras/01-man-pages/ instead of http://swcarpentry.github.io/shell-extras/01-man-pages/index.html)