### PR TITLE
Fixed command typos

### DIFF
--- a/_episodes/02-ssh.md
+++ b/_episodes/02-ssh.md
@@ -366,10 +366,10 @@ Password: ********
 ~~~
 {: .bash}
 
-Paste the content that you copy at the end of `~/.ssh/authorized_keys`.
+Paste the content that you copy at the end of `~/.ssh/authorized_keys`. 
 
 ~~~
-    moon> nano ~/.ssh/authorized_keys`.
+    moon> nano ~/.ssh/authorized_keys
 ~~~
 {: .bash}
 
@@ -462,7 +462,7 @@ and of course, we will use `scp` to do this, even though we don't
 yet have passwordless SSH access set up.
 
 ~~~
-$ scp ~/.ssh/id_rsa.pub vlad@comet:.ssh/authorized_keys"
+$ scp ~/.ssh/id_rsa.pub vlad@comet:.ssh/authorized_keys
 Password: ********
 ~~~
 {: .bash}
@@ -492,7 +492,7 @@ Whilst the authorized keys file is not considered to be highly sensitive,
 the man page's recommendations
 
 ~~~
-$ ssh vlad@comet "chmod go-r ~/.ssh/authorized_keys ; ls -l ~/.ssh"
+$ ssh vlad@comet "chmod go-r ~/.ssh/authorized_keys; ls -l ~/.ssh"
 ~~~
 {: .bash}
 


### PR DESCRIPTION
- No trailing `` `. `` when creating `authorized_keys`
- No trailing double quote when `scp`ing `id_rsa.pub`
- Removed extra space to make commands in the episode look consistent

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
