### PR TITLE
Suggested updates to the shell-extras setup

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ lessons on particular shell features that are useful to researchers.
 > ## Prerequisites
 >
 > All of this material assumes that learners have mastered
-> the basic Unix shell lesson.  
+> the basic [Unix Shell](http://swcarpentry.github.io/shell-novice/) lesson.  
 {: .prereq}
 
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -3,4 +3,17 @@ layout: page
 title: Setup
 ---
 
+## Download files
 There are no files to download for this lesson.
+
+
+## Open a new shell
+This lesson supplements material covered in the [Introduction to the Unix Shell][install shell]. The shell software necessary for this lesson should therefore already be installed. 
+
+1. Open a terminal.
+2. In the terminal type `cd` then press the <kbd>Return</kbd> key.
+   This step will make sure you start with your home folder as your working directory. 
+   You can then navigate to the specific directory you want to work in or run the exercises from there. 
+
+
+[install_shell]: https://carpentries.github.io/workshop-template/#shell


### PR DESCRIPTION
Added more explicit instructions to the setup page with links/references to the Unix Shell Introductory lesson. This would be useful especially to learners that might want to rush through the material, by directing them back in case they get get stumped while starting out on the advanced material. 
