### PR TITLE
Fix file extension typo in 10: AWK

### DIFF
--- a/_episodes/10_awk.md
+++ b/_episodes/10_awk.md
@@ -42,7 +42,7 @@ Example:
 $ awk '{print $0}' example.txt
 ~~~
 
-This command has the same output of "cat": it prints each line from the example.fasta
+This command has the same output of "cat": it prints each line from the example.txt
 file.
 
 The structure of the instruction is the following:


### PR DESCRIPTION
As far as I can tell there was a typo in the file extension name in the main text; changed it to match the command above.